### PR TITLE
Ignore temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+*.pyc


### PR DESCRIPTION
build/ or *.py should never be added to git, so add them to .gitignore.
This also helps to remove clutter in the output of git status
